### PR TITLE
Format mailto: as defined in the specs

### DIFF
--- a/Controller/Website/SecuritytxtWebsiteController.php
+++ b/Controller/Website/SecuritytxtWebsiteController.php
@@ -56,7 +56,7 @@ class SecuritytxtWebsiteController extends AbstractController
             $expires = $entity->getExpires();
             $expires = new DateTime($expires);
 
-            $content .= 'Contact: '.$entity->getContact()."\n";
+            $content .= 'Contact: '.str_replace('mailto://', 'mailto:', $entity->getContact())."\n";
             $content .= 'Expires: '.$expires->format(DateTime::ATOM)."\n";
             if (is_string($entity->getEncryption()) && ($entity->getEncryption() !== '')) {
                 $content .= 'Encryption: '.$entity->getEncryption()."\n";


### PR DESCRIPTION
Sulu returns mailto references as `mailto://` links, the [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116#section-2.5.3) mentions `mailto:` links without the double slashes.